### PR TITLE
MATTER-3938: removed all mentions of SMG repo from documentation, pointing to upda…

### DIFF
--- a/sld251-matter-thread/build-flash-mad.md
+++ b/sld251-matter-thread/build-flash-mad.md
@@ -36,7 +36,7 @@ If you are coming from Simplicity Studio, you may have already installed the dem
 There are two ways to build a Matter Accessory Device image file. You can build it using the Silicon Labs Matter GitHub Repo or you can build it using Simplicity Studio. The entire build process for Simplicity Studio is covered in the [Matter Over Thread Quick Start Guide](/matter/{build-docspace-version}/matter-light-switch-example/02-thread-light-switch-example).
 There are two ways to build a Matter Accessory Device image file. You can build it using the Silicon Labs Matter GitHub Repo or you can build it using Simplicity Studio. The entire build process for Simplicity Studio is covered in the [Matter Over Thread Quick Start Guide](/matter/{build-docspace-version}/matter-light-switch-example/02-thread-light-switch-example).
 
-- [Build Using the Matter GitHub Repo](https://github.com/project-chip/connectedhomeip/tree/e4c8fb6bac7312ac72d287738720494018c3ec80/examples/lighting-app/silabs)
+- [Build Using the Matter GitHub Repo](https://github.com/project-chip/connectedhomeip/tree/master/examples/lighting-app/silabs)
 - [Build Using Simplicity Studio](/matter/{build-docspace-version}/matter-light-switch-example/02-thread-light-switch-example)
 
 ## Step 2: Flash the Matter Accessory Device

--- a/sld251-matter-thread/build-flash-mad.md
+++ b/sld251-matter-thread/build-flash-mad.md
@@ -36,7 +36,7 @@ If you are coming from Simplicity Studio, you may have already installed the dem
 There are two ways to build a Matter Accessory Device image file. You can build it using the Silicon Labs Matter GitHub Repo or you can build it using Simplicity Studio. The entire build process for Simplicity Studio is covered in the [Matter Over Thread Quick Start Guide](/matter/{build-docspace-version}/matter-light-switch-example/02-thread-light-switch-example).
 There are two ways to build a Matter Accessory Device image file. You can build it using the Silicon Labs Matter GitHub Repo or you can build it using Simplicity Studio. The entire build process for Simplicity Studio is covered in the [Matter Over Thread Quick Start Guide](/matter/{build-docspace-version}/matter-light-switch-example/02-thread-light-switch-example).
 
-- [Build Using the Matter GitHub Repo](https://github.com/SiliconLabs/matter/blob/latest/examples/lighting-app/silabs/efr32/README.md)
+- [Build Using the Matter GitHub Repo](https://github.com/project-chip/connectedhomeip/tree/e4c8fb6bac7312ac72d287738720494018c3ec80/examples/lighting-app/silabs)
 - [Build Using Simplicity Studio](/matter/{build-docspace-version}/matter-light-switch-example/02-thread-light-switch-example)
 
 ## Step 2: Flash the Matter Accessory Device

--- a/sld407-matter-ota/02-ota-software-update.md
+++ b/sld407-matter-ota/02-ota-software-update.md
@@ -178,7 +178,7 @@ Multi-Chip OTA is implemented for EFR32 and SiWx917 NCP/SoC devices. Multi-chip 
 
 The script can be obtained from the Matter Extension github repository.
 
-For more information on creating a Multi-Chip .ota file, see the [README.md](https://github.com/SiliconLabs/matter/blob/latest/scripts/tools/silabs/ota/README.md).
+For more information on creating a Multi-Chip .ota file, see the [README.md](https://github.com/project-chip/connectedhomeip/blob/master/scripts/tools/silabs/ota/README.md).
 
 Applications must be built with the OTA Multi Image Requestor component added to the project in Simplicity Studio to enable them to process the TLVs.
 

--- a/sld407-matter-ota/03-firmware-upgrades.md
+++ b/sld407-matter-ota/03-firmware-upgrades.md
@@ -25,10 +25,10 @@ commands on a Linux terminal running on either Linux machine, WSL or Virtual
 Machine to clone the repository and run bootstrap to prepare to build the sample
 application images.
 
-1. To download the [SiliconLabs Matter codebase](https://github.com/SiliconLabs/matter.git) run the following commands.
+1. To download the [SiliconLabs Matter codebase](https://github.com/project-chip/connectedhomeip.git) run the following commands.
 
     ```shell
-     $ git clone https://github.com/SiliconLabs/matter.git
+     $ git clone https://github.com/project-chip/connectedhomeip.git
     ```
 
 2. Bootstrapping:


### PR DESCRIPTION
…ted docs in CSA repo

## Description
<!-- Provide a brief description of the changes in this pull request. -->
Some of the documentation still refers to the SMG repo, this PR changed these references to the equivalent documentation in the CSA repo to ensure the most up to date information. 

## Related Issue
<!-- If this pull request addresses an issue, link to it here. -->
Closes [MATTER-3938](https://jira.silabs.com/browse/MATTER-3938)

## Changes Made
<!-- List the changes made in this pull request. -->
- sld251-matter-thread/build-flash-mad.md: Point to lighting app README in CSA repo instead of in SMG repo
- sld407-matter-ota/02-ota-software-update.md: Point to README for creating a Multi-Chip .ota file in the CSA repo instead of the SMG repo. 
- sld407-matter-ota/03-firmware-upgrades.md: Changed instructions from cloning SMG repo to CSA repo and updated link to CSA repo rather than SMG repo. 

## Checklist
- [X] I have read the [Contributor License Agreement](https://github.com/SiliconLabsSoftware/agreements-and-guidelines/blob/main/contributor_license_agreement.md).
- [X] I have followed the repository's [coding guidelines](https://github.com/SiliconLabsSoftware/agreements-and-guidelines/blob/main/coding_standard.md) .
- [X] I have checked the action workflow results and they are all passed.

## Screenshots (if applicable)
<!-- Add screenshots to help explain the changes (if applicable). -->

## Additional Notes
<!-- Add any additional information or context. -->
