### PR TITLE
Matterhub link fix

### DIFF
--- a/sld247-matter-overview/index.md
+++ b/sld247-matter-overview/index.md
@@ -85,7 +85,7 @@ Pre-built images for the SiWx917 connectivity firmware are available per the ins
 
 **Installation of Wi-Fi SDK and WiSeConnect Packages**: The following packages will be installed during the installation of Simplicity Studio. Refer to [Package Installation](/matter/{build-docspace-version}/matter-wifi-getting-started-example/software-installation).
 
-**Matter Hub Raspberry Pi Image**: A copy of the pre-built image from the Silicon Labs web services can be downloaded in this [zipfile](https://www.silabs.com/documents/public/software/SilabsMatterPi_2.5.0-1.4-extension.zip). **Note** this is a large file and will take some time to download.
+**Matter Hub Raspberry Pi Image**: A copy of the pre-built image from the Silicon Labs web services can be downloaded in this [zipfile](https://www.silabs.com/documents/public/software/SilabsMatterPi_2.6.0-1.4-extension.zip). **Note** this is a large file and will take some time to download.
 
 >**Note:** The Matter hub for Matter over Thread requires an additional device, a radio co-processor. See [the introduction to the Matter over Thread demo](/matter/{build-docspace-version}/matter-light-switch-example/02-thread-light-switch-example) for more information.
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this pull request. -->
Need to fix a link for matterhub image to latest version

## Related Issue
<!-- If this pull request addresses an issue, link to it here. -->
Closes #<issue_number>
NOJIRA

## Changes Made
<!-- List the changes made in this pull request. -->
- Updated link to point at v2.6.0

## Checklist
- [x] I have read the [Contributor License Agreement](https://github.com/SiliconLabsSoftware/agreements-and-guidelines/blob/main/contributor_license_agreement.md).
- [x] I have followed the repository's [coding guidelines](https://github.com/SiliconLabsSoftware/agreements-and-guidelines/blob/main/coding_standard.md) .
- [x] I have checked the action workflow results and they are all passed.

## Screenshots (if applicable)
<!-- Add screenshots to help explain the changes (if applicable). -->

## Additional Notes
<!-- Add any additional information or context. -->
