### PR TITLE
Update version strings to 2.6.1

### DIFF
--- a/sld249-matter-prerequisites/hardware-requirements.md
+++ b/sld249-matter-prerequisites/hardware-requirements.md
@@ -28,10 +28,20 @@ Over 60 Silicon Labs boards support running the RCP firmware. To build an image 
   - BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
     - [XG24-RB4187C](https://www.silabs.com/development-tools/wireless/xg24-rb4187c-efr32xg24-wireless-gecko-radio-board)
 
+- **MGM24 boards:**
+  - BRD4316A / SLWSTK6006A / Wireless Start Kit / 2.4GHz@10dBm -  xGM240-RB4316A
+  - BRD4317A / SLWSTK6006A / Wireless Starter Kit/ 2.4GHz@20dBm -  xGM240-RB4317A
+  - BRD4318A / SLWSTK6006A / Wireless Starter Kit/ 2.4GHz@20dBm -  xGM240-RB4318A
+  - BRD4319A (Rev A00 only) / SLWSTK6006A / Wireless Starter Kit/ 2.4GHz@20dBm
+  - BRD2704A / Sparkfun Thing Plus MGM240P 
+  - BRD4337A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm -  xGM240-RB4337A
+
 - **MG26 boards:**
   - BRD4116A / 2.4GHz@10dBm
   - BRD4117A / 2.4GHz@20dBm
   - BRD4118A / 2.4GHz@20dBm
+  - BRD4120A
+  - BRD4121A
   - BRD2608A
   - BRD2709A
 
@@ -53,25 +63,33 @@ The Matter Accessory Device (MAD) is the actual device that the Matter applicati
   - BRD2703A / MG24 Explorer Kit
   - BRD2601B / MG24 Explorer Kit
     - [XG24-DK2601B](https://www.silabs.com/development-tools/wireless/efr32xg24-dev-kit?tab=overview)
-  - BRD4319A / SLWSTK6006A / Wireless Starter Kit/ 2.4GHz@20dBm
+  
 
-    **Note**:  Only the A00 revision of this board is supported, other revisions do not have enough RAM to run Matter.
-
-  - BRD4316A / SLWSTK6006A / Wireless Start Kit / 2.4GHz@10dBm
-    - [XGM240-RB4316A](https://www.silabs.com/development-tools/wireless/xgm240-rb4316a-xgm240p-module-radio-board?tab=overview)
-  - BRD4317A / SLWSTK6006A / Wireless Starter Kit/ 2.4GHz@20dBm
-    - [XGM240-RB4317A](https://www.silabs.com/development-tools/wireless/xgm240-rb4317a-xgm240p-module-radio-board?tab=overview)
+- **MGM24 boards:**
+  - BRD4316A / SLWSTK6006A / Wireless Start Kit / 2.4GHz@10dBm -  xGM240-RB4316A
+  - BRD4317A / SLWSTK6006A / Wireless Starter Kit/ 2.4GHz@20dBm -  xGM240-RB4317A
+  - BRD4318A / SLWSTK6006A / Wireless Starter Kit/ 2.4GHz@20dBm -  xGM240-RB4318A
+  - BRD4319A (Rev A00 only) / SLWSTK6006A / Wireless Starter Kit/ 2.4GHz@20dBm
+  - BRD2704A / Sparkfun Thing Plus MGM240P 
+  - BRD4337A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm -  xGM240-RB4337A
 
 - **MG26 boards**
   - BRD4116A / 2.4GHz@10dBm
   - BRD4117A / 2.4GHz@20dBm
   - BRD4118A / 2.4GHz@20dBm
+  - BRD4120A
+  - BRD4121A
   - BRD2608A
   - BRD2709A
 
 - **MGM26 boards:**
   - BRD4350A
   - BRD4351A
+
+- **MGM301 boards:**
+  - BRD2719A
+  - BRD4407A
+  - BRD4408A
 
 ## Matter Over Wi-Fi Accessory Device Requirements
 

--- a/sld249-matter-prerequisites/matter-artifacts.md
+++ b/sld249-matter-prerequisites/matter-artifacts.md
@@ -4,7 +4,7 @@ This page provides links to pre-built software image "artifacts" that can be use
 
 Images for the items listed below are available under the "Assets" section at the bottom of this page:
 
-https://github.com/SiliconLabs/matter_extension/releases/tag/v2.6.0
+https://github.com/SiliconLabs/matter_extension/releases/tag/v2.6.1
 
 ## Matter Hub Raspberry Pi Image
 
@@ -16,25 +16,25 @@ https://www.silabs.com/documents/public/software/SilabsMatterPi_2.5.0-1.4-extens
 
 The Radio Co-Processor firmware is used to turn an EFR into an RCP that can be used with a Raspberry Pi to allow the Raspberry Pi's Open Thread Border Router to access the Thread network. Radio Co-Processor (RCP) images are available in the Assets section of this page:
 
-https://github.com/SiliconLabs/matter_extension/releases/download/v2.6.0/ot-rcp-binaries-2.6.0-1.4.zip
+https://github.com/SiliconLabs/matter_extension/releases/download/v2.6.1/ot-rcp-binaries-2.6.1-1.4.zip
 
 ## Matter Accessory Device Images
 
 The Matter Accessory Device Images are used to turn an EFR into a Matter device. These are pre-built binary images for the Matter Demo. Matter Accessory Device Images are located in the Assets section of this page:
 
-https://github.com/SiliconLabs/matter_extension/releases/download/v2.6.0/matter-accessory-device-images_2.6.0-1.4.zip
+https://github.com/SiliconLabs/matter_extension/releases/download/v2.6.1/matter-accessory-device-images_2.6.1-1.4.zip
 
 ## Matter Bootloader Binaries
 
 All Silicon Labs board supporting Matter require that a bootloader binary is flashed to the device along with the application image. Bootloader binaries for all of the Matter supported devices are available here:
 
-https://github.com/SiliconLabs/matter_extension/releases/download/v2.6.0/bootloader_binaries_matter_extension_v2.6.0-1.4.zip
+https://github.com/SiliconLabs/matter_extension/releases/download/v2.6.1/bootloader_binaries_matter_extension_v2.6.1-1.4.zip
 
 ## RS9116 Firmware
 
 The RS9116 firmware (`rs9116_firmware_files_with_rev.zip`) is used to update the RS9116 which can be found in the Assets section of this page:
 
-https://github.com/SiliconLabs/matter_extension/releases/download/v2.6.0/rs9116_firmware_files_with_rev_2.6.0-1.4.zip
+https://github.com/SiliconLabs/matter_extension/releases/download/v2.6.1/rs9116_firmware_files_with_rev_2.6.1-1.4.zip
 
 **Note**:
 RS9116 chip/module needs to be flashed with proper firmware as mentioned below:
@@ -46,7 +46,7 @@ RS9116 chip/module needs to be flashed with proper firmware as mentioned below:
 
 The SiWx917 firmware(SiWx917_firmware_files.zip) is used to update the SiWN917 NCP and SiWG917 SOC which can be found in the Assets section of this page:
 
-https://github.com/SiliconLabs/matter_extension/releases/download/v2.6.0/SiWx917_firmware_files_2.6.0-1.4.zip
+https://github.com/SiliconLabs/matter_extension/releases/download/v2.6.1/SiWx917_firmware_files_2.6.1-1.4.zip
 
 **Note**:
 
@@ -64,12 +64,12 @@ https://github.com/SiliconLabs/matter_extension/releases/download/v2.6.0/SiWx917
 
 The SiWx917 RCP folder (siwx917_rcp_files.zip) contains the Matter Linux all-cluster-app, which can be run on a Raspberry Pi, and the wfx-sdio-overlay.dts file, a Device Tree Source file used to configure the SDIO interface on the Raspberry Pi to detect and communicate with the SiWx917 RCP.
 
-https://github.com/SiliconLabs/matter_extension/releases/download/v2.6.0/siwx917_rcp_files.zip
+https://github.com/SiliconLabs/matter_extension/releases/download/v2.6.1/siwx917_rcp_files.zip
 
 ## SiWx917 SoC Configuration Files For JLink RTT Logging
 
 To check device logs on JLink RTT for the Matter Application on the SiWx917 SoC, the **JLink RTT** must be configured for the SiWx917 SoC device by following the instructions on the [JLink RTT SOC Support](/matter/{build-docspace-version}/matter-wifi-enabling-features/jlink-soc-setup) for SiWx917 SoC.
 
-The [JLinkDevices.xml](https://github.com/SiliconLabs/matter_extension/releases/download/v2.6.0/JLinkDevices.xml.zip) and [RS9117_SF_4MB_42bsp.elf](https://github.com/SiliconLabs/matter_extension/releases/download/v2.6.0/RS9117_SF_4MB_42bsp.elf.zip) files referenced in the instructions may be found in the Assets section of this page.
+The [JLinkDevices.xml](https://github.com/SiliconLabs/matter_extension/releases/download/v2.6.1/JLinkDevices.xml.zip) and [RS9117_SF_4MB_42bsp.elf](https://github.com/SiliconLabs/matter_extension/releases/download/v2.6.1/RS9117_SF_4MB_42bsp.elf.zip) files referenced in the instructions may be found in the Assets section of this page.
 
 >**Note**: For EFR32MG2x devices, JLink RTT Logging support is already enabled.

--- a/sld250-matter-references/versioning-release-maintenance.md
+++ b/sld250-matter-references/versioning-release-maintenance.md
@@ -70,4 +70,5 @@ Update digits based on the following criteria:
 |  v2.5.0-1.4  |  18-Dec-24     | 2024.12.0                      | v3.4.0   | 1.4 | Obsolete     |
 |  v2.5.1-1.4  |  12-Feb-25     | 2024.12.1                      | v3.4.1   | 1.4 | Obsolete     |
 |  v2.5.2-1.4  |  10-Apr-25     | 2024.12.2                      | v3.4.2   | 1.4 | Maintained     |
-|  v2.6.0-1.4  |  18-Jun-25     | 2025.6.0                       | v3.5.0   | 1.4 | Active     |
+|  v2.6.0-1.4  |  18-Jun-25     | 2025.6.0                       | v3.5.0   | 1.4 | Maintained     |
+|  v2.6.1-1.4  |  23-Jul-25     | 2025.6.1                       | v3.5.1   | 1.4 | Active     |

--- a/sld290-matter-wifi-getting-started-example/index.md
+++ b/sld290-matter-wifi-getting-started-example/index.md
@@ -8,7 +8,7 @@ To get started with Matter over Wi-Fi, download the latest version of Simplicity
 
 ## Setting up the Matter over Wi-Fi Development Environment
 
-Refer to the [Release Notes](https://github.com/SiliconLabs/matter_extension/releases/tag/v2.6.0) to know more about the latest releases from Silicon Labs.
+Refer to the [Release Notes](https://github.com/SiliconLabs/matter_extension/releases/tag/v2.6.1) to know more about the latest releases from Silicon Labs.
 
 To control the Matter Accessory Device, a controller is required which is termed as **chip-tool**. The chip-tool can be set up in two ways:
 

--- a/sld388-matter-new-features/index.md
+++ b/sld388-matter-new-features/index.md
@@ -1,5 +1,12 @@
 # New Features
 
+## New Features for v2.6.1-1.4
+
+- Quality-tested Matter 1.4.1 solution for Thread MG24 / MG26, Wi-Fi SiWx917 SoC and NCP mode, Wi-Fi MG24/WF200 and Wi-Fi MG24/RS9116 (non-sleepy).
+ - For Wi-Fi SiWx917 SoC and NCP mode, there are known timeout issues in certain stress test conditions, which have not been observed with ecosystems under normal conditions. For details see the Known Issues section of the [Release Notes](https://github.com/SiliconLabs/matter_extension/releases/tag/v2.6.1).
+- Works with Simplicity SDK v2025.6.1 and WiSeConnect SDK v3.5.1
+- Miscellaneous bug fixes and improvements.
+
 ## New Features for v2.6.0-1.4
 
 - Quality-tested Matter 1.4.1 solution for Thread MG24 / MG26, Wi-Fi SiWx917 SoC and NCP mode, Wi-Fi MG24/WF200 and Wi-Fi MG24/RS9116 (non-sleepy).

--- a/sld477-matter-quick-start-demo/01-wifi-quick-start-demo.md
+++ b/sld477-matter-quick-start-demo/01-wifi-quick-start-demo.md
@@ -4,7 +4,7 @@ This Quick-Start Guide will demo the out-of-box experience for adding an SiWx917
 
 ## Software Requirements
 
-- Simplicity Studio v5 with SiSDK - 2025.6.0 + Silicon Labs Matter - 2.6.0 + WiSeConnect - 3.5.0
+- Simplicity Studio v5 with SiSDK - 2025.6.1 + Silicon Labs Matter - 2.6.1 + WiSeConnect - 3.5.1
 - Simplicity Connect mobile App on Smartphone
 
 ## Hardware Requirements

--- a/sld477-matter-quick-start-demo/02-thread-quick-start-demo.md
+++ b/sld477-matter-quick-start-demo/02-thread-quick-start-demo.md
@@ -4,7 +4,7 @@ This Quick-Start Guide will demo the out-of-box experience for adding an EFR32MG
 
 ## Software Requirements
 
-- Simplicity Studio v5 with SiSDK - 2025.6.0 + Silicon Labs Matter - 2.6.0
+- Simplicity Studio v5 with SiSDK - 2025.6.1 + Silicon Labs Matter - 2.6.1
 - Simplicity Connect mobile App on Smartphone
 
 ## Hardware Requirements

--- a/sld57-matter-landing-page/index.md
+++ b/sld57-matter-landing-page/index.md
@@ -20,7 +20,7 @@ The [Silicon Labs Matter GitHub repo](https://github.com/SiliconLabs/matter) wil
 
 ## Other Resources
 
-**To see release notes** containing a list of features and known issues, go to [Matter Release Notes on Silicon Labs Matter Extension](https://github.com/SiliconLabs/matter_extension/releases/tag/v2.6.0).
+**To see release notes** containing a list of features and known issues, go to [Matter Release Notes on Silicon Labs Matter Extension](https://github.com/SiliconLabs/matter_extension/releases/tag/v2.6.1).
 
 **If you are new to Matter** or would like more information about Silicon Labs Matter-based products, see the [Matter content on silabs.com](https://www.silabs.com/wireless/matter).
 

--- a/sld601-matter-application-development/index.md
+++ b/sld601-matter-application-development/index.md
@@ -1,6 +1,6 @@
 # Introduction
 
-This section covers application development topics. Silicon Labs will build out this section over time. For Matter v2.6.0, we provide:
+This section covers application development topics. Silicon Labs will build out this section over time. For Matter v2.6.1, we provide:
 
 - [Matter Scenes Quick Start Guide](./matter-scenes-quick-start-guide)
 - [Matter Event and Timer Guide](./matter-event-timer-guide.md)


### PR DESCRIPTION
## Description
Update version strings to 2.6.1

## Related Issue
N/A

## Changes Made
- Update version string to Matter 2.6.1, SiSDK 2025.6.1 and WiFi SDK to 3.5.1
- Update the HW requirements page

## Checklist
- [ X] I have read the [Contributor License Agreement](https://github.com/SiliconLabsSoftware/agreements-and-guidelines/blob/main/contributor_license_agreement.md).
- [ X] I have followed the repository's [coding guidelines](https://github.com/SiliconLabsSoftware/agreements-and-guidelines/blob/main/coding_standard.md) .
- [X ] I have checked the action workflow results and they are all passed.

## Screenshots (if applicable)
N/A

## Additional Notes
N/A
