### PR TITLE
update cluster.md to correct Cluster header file link

### DIFF
--- a/sld295-matter-api-reference/cluster.md
+++ b/sld295-matter-api-reference/cluster.md
@@ -13,4 +13,4 @@ For more details see: [Matter Data Model](../sld288-matter-fundamentals-data-mod
 
 The header file below contains namespaces and IDs of Clusters. In Simplicity Studio, this will be generated in the autogen/zap-generated/ folder of the matter project.
 
-- [Cluster](https://github.com/SiliconLabs/matter_extension/blob/main/third_party/matter_sdk/zzz_generated/app-common/app-common/zap-generated/ids/Clusters.h)
+- [Cluster](https://github.com/project-chip/connectedhomeip/blob/master/zzz_generated/app-common/app-common/zap-generated/ids/Clusters.h)


### PR DESCRIPTION
## Description
In the Header file section of this page https://docs.silabs.com/matter/latest/matter-api-reference/cluster#header-file the link is broken.

## Related Issue
Closes #15 

## Changes Made
update cluster.md to correct Cluster header file link

## Checklist
- [x] I have read the [Contributor License Agreement](https://github.com/SiliconLabsSoftware/agreements-and-guidelines/blob/main/contributor_license_agreement.md).
- [x] I have followed the repository's [coding guidelines](https://github.com/SiliconLabsSoftware/agreements-and-guidelines/blob/main/coding_standard.md) .
- [x] I have checked the action workflow results and they are all passed.