### PR TITLE
RS9116 deprecation documentation

### DIFF
--- a/sld120-matter-wifi-getting-started/04-light-switch-step-by-step-example.md
+++ b/sld120-matter-wifi-getting-started/04-light-switch-step-by-step-example.md
@@ -40,7 +40,7 @@ Matter hub/chip-tool are ready and working. Keep the PuTTY session open for the 
 
    4. Open the Example Projects and Demos tab, select the **Matter** filter and enter "_Wi-Fi_" in **Filter on keywords**.
 
-   5. Select the _Matter - SoC Lighting over Wi-Fi_ example for RS9116, click **Create**, rename the project if you wish, and click **Finish**.
+   5. Select the _Matter - SoC Lighting over Wi-Fi_ example for SiWx917, click **Create**, rename the project if you wish, and click **Finish**.
 
    6. Once the project is created, the perspective changes to the Simplicity IDE perspective. In the Project Explorer view, right-click the project and select _Build Project_.
 

--- a/sld246-matter-faq/wifi-faq.md
+++ b/sld246-matter-faq/wifi-faq.md
@@ -82,6 +82,8 @@ Where `mySSID` is **your AP's SSID** and `mypassword` is **your AP's password**.
 
 ### 3. WLAN connection fails from RS9116 during commissioning when channel 13 is selected on the AP
 
+**Note:** RS9116 is deprecated and no longer supported on Matter.
+
 The required channel becomes available for connection when the WLAN connection region is configured during compilation to one that supports the channel, such as for Japan for channel 13.
 
 In order to use the desired channel, before building, make sure the WLAN connection region is configured correctly by reviewing/modifying the following lines in **/examples/platform/silabs/efr32/rs911x/rsi_wlan_config.h**:
@@ -167,6 +169,8 @@ Disable QR Code and enable CHIP Logging:
 `./scripts/examples/gn_efr32_example.sh examples/lock-app/efr32 out/wf200_lock_app BRD4161A is_debug=false show_qr_code=false --wifi wf200 |& tee out/wf200_lock.log`
 
 ### 11. MG24 device sometimes loses its connection to Ozone during OTA Update with RS9116
+
+**Note:** RS9116 is deprecated and no longer supported on Matter.
 
 While performing an OTA Update with the EFR32MG24 + RS9116 device combination, when the device is reset and bootloading begins with the new image, the Ozone Debugger sometimes loses its connection.
 

--- a/sld247-matter-overview/index.md
+++ b/sld247-matter-overview/index.md
@@ -38,7 +38,7 @@ The following boards are supported for the Matter over Wi-Fi demos and developme
     - [XG24-RB4187C](https://www.silabs.com/development-tools/wireless/xg24-rb4187c-efr32xg24-wireless-gecko-radio-board)
     - MG24 with WSTK: [xG24-PK6010A](https://www.silabs.com/development-tools/wireless/efr32xg24-pro-kit-20-dbm?tab=overview)
 - **Wi-Fi NCP Dev Kits & boards**
-  - **RS9116**
+  - **RS9116** (**Note:** RS9116 is deprecated and no longer supported on Matter.)
     - SB-EVK1 / Single Band Wi-Fi Development Kit / 2.4GHz
       - [RS9116X-SB-EVK1](https://www.silabs.com/development-tools/wireless/wi-fi/rs9116x-sb-evk-development-kit)
     - SB-EVK2 / Single Band Wi-Fi Development Kit / 2.4GHz

--- a/sld249-matter-prerequisites/matter-artifacts.md
+++ b/sld249-matter-prerequisites/matter-artifacts.md
@@ -36,6 +36,8 @@ The RS9116 firmware (`rs9116_firmware_files_with_rev.zip`) is used to update the
 
 https://github.com/SiliconLabs/matter_extension/releases/download/v2.6.1/rs9116_firmware_files_with_rev_2.6.1-1.4.zip
 
+**Note**: RS9116 is deprecated and no longer supported on Matter.
+
 **Note**:
 RS9116 chip/module needs to be flashed with proper firmware as mentioned below:
 

--- a/sld249-matter-prerequisites/software-requirements.md
+++ b/sld249-matter-prerequisites/software-requirements.md
@@ -36,9 +36,13 @@ Below are the software tools both optional and required for developing Matter ov
 
 2. [WiSeConnect SDK v2.x for RS9116 NCP](/matter/{build-docspace-version}/matter-wifi-getting-started-example/software-installation#installation-of-wiseconnect-sdk-v2x-or-v3x-extension), which can be installed as part of the Simplicity Studio tool installation.
 
+   **Note:** RS9116 is deprecated and no longer supported on Matter.
+
 3. [WiSeConnect SDK v3.x for SiWx917 NCP](/matter/{build-docspace-version}/matter-wifi-getting-started-example/software-installation#installation-of-wiseconnect-sdk-v2x-or-v3x-extension), which can be installed as part of the Simplicity Studio tool installation.
 
 4. [Firmware for RS9116 NCP](./matter-artifacts.md#rs9116-firmware)
+
+   **Note**: RS9116 is deprecated and no longer supported on Matter.
 
 5. [Firmware for SiWx917 NCP](./matter-artifacts.md#siwx917-firmware-for-siwn917-ncp-and-siwg917-soc)
 

--- a/sld290-matter-wifi-getting-started-example/getting-started-efx32-ncp.md
+++ b/sld290-matter-wifi-getting-started-example/getting-started-efx32-ncp.md
@@ -18,6 +18,9 @@ The following hardware devices are required for executing Matter over Wi-Fi:
       - RS9116 development kit
       - WF200 expansion board
       - SiWx917 NCP expansion board
+
+  **Note:** RS9116 is deprecated and no longer supported on Matter.
+
 - **MG24 boards**
 
   - BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
@@ -27,11 +30,13 @@ The following hardware devices are required for executing Matter over Wi-Fi:
     - [XG24-RB4187C](https://www.silabs.com/development-tools/wireless/xg24-rb4187c-efr32xg24-wireless-gecko-radio-board)
     - MG24 with WSTK : [xG24-PK6010A](https://www.silabs.com/development-tools/wireless/efr32xg24-pro-kit-20-dbm?tab=overview)
   
-    >**Note:** A custom board binary can also be generated. The configuration file `sl_spidrv_eusart_exp_config` for RS9116 and `sl_spidrv_exp_config` for 917NCP and WF200 should have the SPI pin and port defines enabled. The configuration file `sl_custom_board.h` contains the SPI pins, which should be updated according to the custom board's pin configuration.
+    >**Note:** A custom board binary can also be generated. The configuration file `sl_spidrv_eusart_exp_config` for RS9116 and `sl_spidrv_exp_config` for 917NCP and WF200 should have the SPI pin and port defines enabled. The configuration file `sl_custom_board.h` contains the SPI pins, which should be updated according to the custom board's pin configuration. RS9116 is deprecated and no longer supported on Matter.
 
 - **Wi-Fi Dev Kits & boards**
 
   - **RS9116**
+
+    **Note** : RS9116 is deprecated and no longer supported on Matter.
     - SB-EVK1 / Single Band Wi-Fi Development Kit / 2.4GHz
       - [RS9116X-SB-EVK1](https://www.silabs.com/development-tools/wireless/wi-fi/rs9116x-sb-evk-development-kit)
     - SB-EVK2 / Single Band Wi-Fi Development Kit / 2.4GHz

--- a/sld291-matter-wifi-run-demo/flashing-using-commander.md
+++ b/sld291-matter-wifi-run-demo/flashing-using-commander.md
@@ -7,9 +7,14 @@ Before flashing the application for EFR32 Boards, flash **bootloader images** as
 - **BRD4186C Board**
   - For MG24 + RS9116: Internal Bootloader (bootloader-storage-internal-single-512k-BRD4186C-gsdk4.1)
   - For MG24 + WF200: External Bootloader (bootloader-storage-spiflash-single-1024k-BRD4186C-gsdk4.1)
+
+  **Note**: RS9116 is deprecated and no longer supported on Matter.
+
 - **BRD4187C Board**
   - For MG24 + RS9116: Internal Bootloader (bootloader-storage-internal-single-512k-BRD4187C-gsdk4.1)
   - For MG24 + WF200: External Bootloader (bootloader-storage-spiflash-single-1024k-BRD4187C-gsdk4.1)
+
+  **Note**: RS9116 is deprecated and no longer supported on Matter.
 
 Bootloader binaries are available in the respective path of codebase **third_party/silabs/matter_support/matter/efr32/bootloader_binaries** folder. Silicon Labs recommends always flashing the latest bootloader binaries from the codebase.
 

--- a/sld291-matter-wifi-run-demo/loading-firmware-for-ncp-and-soc-boards.md
+++ b/sld291-matter-wifi-run-demo/loading-firmware-for-ncp-and-soc-boards.md
@@ -14,6 +14,8 @@ The SiWx917 NCP or RS9116 EVK connectivity firmware can be upgraded using Tera T
 
 #### Firmware Upgrade On RS9116
 
+**Note**: RS9116 is deprecated and no longer supported on Matter.
+
 1. Connect the EVK to PC using the USB interface labeled **UART** as identified below.
 
    ![Switch Position before firmware flash](./images/rs916-board.png)

--- a/sld292-matter-wifi-enabling-features/wifi-sleepy-end-device.md
+++ b/sld292-matter-wifi-enabling-features/wifi-sleepy-end-device.md
@@ -63,9 +63,14 @@ To enable ICD functionality for Wi-Fi, the `ICD Management` cluster/component ne
 - For SiWx917 SOC, click on **Replace Subscription Timeout Resumption**. Sleepy support is enabled; build the project. Sleep support on M4 and TA can be enabled by installing `matter_icd_core` component.
 
 - For rs9116 and WF200: `matter_icd_management` component is installed by default for lock-app. For thermostat and window, you need to install the mentioned cluster/component to enable sleepy.
+
+**Note:** RS9116 is deprecated and no longer supported on Matter.
+
 - For 917NCP: `matter_icd_management` component is installed by default for lock-app. For thermostat and window, you need to install the mentioned cluster/component to enable sleepy.
 
 ### EFR32 + RS9116 Setup for ICDs (Sleepy Devices)
+
+**Note:** RS9116 is deprecated and no longer supported on Matter.
 
 - The following GPIO pins should be connected for 9116 and Host handshakes.
 pin 7 and pin 9 to UULP_2 and UULP_0 respectively.


### PR DESCRIPTION
## Description
RS9116 deprecation documentation

## Changes Made
Added RS9116 deprecation message at all places where RS9116 is present
- 

## Checklist
- [ ] I have read the [Contributor License Agreement](https://github.com/SiliconLabsSoftware/agreements-and-guidelines/blob/main/contributor_license_agreement.md).
- [ ] I have followed the repository's [coding guidelines](https://github.com/SiliconLabsSoftware/agreements-and-guidelines/blob/main/coding_standard.md) .
- [ ] I have checked the action workflow results and they are all passed.

## Screenshots (if applicable)
<!-- Add screenshots to help explain the changes (if applicable). -->

## Additional Notes
<!-- Add any additional information or context. -->
