### PR TITLE
Matter shell 917SoC Sleepy device 

### DIFF
--- a/sld248-matter-overview-guides/serial-port-communications.md
+++ b/sld248-matter-overview-guides/serial-port-communications.md
@@ -121,4 +121,4 @@ To run matter shell on the Silicon Labs Platform, refer to the [Software Require
 
   **Note**: Type **help** in matterCli terminal for more information about supported features.
 
-  **Note**: For 917SoC ICD-enabled devices, only 5 UULP pins are supported. As a result, the matter shell is not functional with sleepy applications since they are not mapped to UULP pins. To enable the Matter shell for Sleepy 917SoC devices, the P37 pin must be pulled up. Additionally, the boards BRD2708A, BRD2911A, and BRD4343A have only 3 UULP GPIO pins, which prevents the shell from functioning. To make it work, users should repurpose existing UULP GPIO pins.
+  **Note**: For 917SoC ICD-enabled devices, only five UULP pins are supported. As a result, the Matter shell is not functional with sleepy applications because they are not mapped to UULP pins. To enable the Matter shell for sleepy 917SoC devices, the P37 pin must be pulled up. Additionally, boards BRD2708A, BRD2911A, and BRD4343A have only three UULP GPIO pins, which prevents the shell from functioning. To enable the shell on these boards, users must repurpose existing UULP GPIO pins.


### PR DESCRIPTION
## Description
Adding the UULP pin to enable the matter shell with the ICD enabled 917SoC and adding the boards where the shell can't be enabled by default i.e., user change is needed

## Related Issue
https://jira.silabs.com/browse/MATTER-5338

## Changes Made
Adding the note for the matter shell

