### PR TITLE
Rename ZclCallbacks.cpp to DataModelCallbacks.cpp

### DIFF
--- a/sld295-matter-api-reference/attributes.md
+++ b/sld295-matter-api-reference/attributes.md
@@ -4,7 +4,7 @@ Attributes represent the current state of a device. For instance if the device i
 
 ## Attribute Changes
 
-When a ZCL attribute is updated in the data model, the framework will call the `postAttributeChangeCallback`. If this callback is implemented by the device it will be informed of the attribute change. The device may react to the attribute change. For example, in the [MatterPostAttributeChangeCallback](https://github.com/SiliconLabs/matter_extension/blob/main/examples/onoff-plug-app/src/ZclCallbacks.cpp#L38), say we want to add some custom handler code to control an RGB LED when on/off attribute in the `On-Off` Cluster changes:
+When a ZCL attribute is updated in the data model, the framework will call the `postAttributeChangeCallback`. If this callback is implemented by the device it will be informed of the attribute change. The device may react to the attribute change. For example, in `MatterPostAttributeChangeCallback` in `DataModelCallbacks.cpp` in [onoff-plug-app/src](https://github.com/SiliconLabs/matter_extension/tree/main/examples/onoff-plug-app/src), say we want to add some custom handler code to control an RGB LED when on/off attribute in the `On-Off` Cluster changes:
 
 ```cpp
 void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, 

--- a/sld601-matter-application-development/matter-application-cluster-logic.md
+++ b/sld601-matter-application-development/matter-application-cluster-logic.md
@@ -100,7 +100,7 @@ void AppTask::OnOffAttributeWriteStartTimer()
 
 This function will have to be defined in AppTask.h as well as part of the AppTask class.
 
-Now, locate the `MatterPostAttributeChangeCallback()` function in the `src/ZclCallbacks.cpp` file. This function is invoked by the application framework after an attribute value has been changed. Because you are modifying the OnOff attribute in the `OnOffTmrExpiryHandler()` function, use this callback to re-initiate the timer so that the attribute continues to toggle. To achieve this, call `AppTask::OnOffAttributeWriteStartTimer()`, which is part of the AppTask context.
+Now, locate the `MatterPostAttributeChangeCallback()` function in the `src/DataModelCallbacks.cpp` file. This function is invoked by the application framework after an attribute value has been changed. Because you are modifying the OnOff attribute in the `OnOffTmrExpiryHandler()` function, use this callback to re-initiate the timer so that the attribute continues to toggle. To achieve this, call `AppTask::OnOffAttributeWriteStartTimer()`, which is part of the AppTask context.
 
 To implement this functionality, first obtain the AppTask instance using `AppTask::GetAppTask()`. Modify the `MatterPostAttributeChangeCallback()` function as shown below:
 
@@ -119,7 +119,7 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
 
 }
 ```
-Make sure to #include "AppTask.h" at the top of the `ZclCallbacks.cpp` file to call the `AppTask::GetAppTask()` function. For more information on the AppTask, refer to AppTask.h.
+Make sure to #include "AppTask.h" at the top of the `DataModelCallbacks.cpp` file to call the `AppTask::GetAppTask()` function. For more information on the AppTask, refer to AppTask.h.
 
 Finally, add a call to `OnOffTmrStart()` at the end of the `AppTask::AppInit()` function to start the attribute write sequence. The following image illustrates the code flow:
 

--- a/sld601-matter-application-development/matter-scenes-quick-start-guide.md
+++ b/sld601-matter-application-development/matter-scenes-quick-start-guide.md
@@ -165,9 +165,9 @@ public:
 
 ### Step 3 Implement Callbacks
 
-Make the following additions to the src/ZclCallbacks.cpp file:
+Make the following additions to the src/DataModelCallbacks.cpp file:
 
-:::collapsed{summary="Click to expand and view the ZclCallbacks.cpp file"}
+:::collapsed{summary="Click to expand and view the DataModelCallbacks.cpp file"}
 ```c++
 // Color Transformer
 #include "ColorTransformer.h"
@@ -192,7 +192,7 @@ bool xyFlag = false;
 ```
 :::
 
-Then, inside `MatterPostAttributeChangeCallback` in _src/ZclCallbacks.cpp_, implement the on/off functionality of the LED:
+Then, inside `MatterPostAttributeChangeCallback` in _src/DataModelCallbacks.cpp_, implement the on/off functionality of the LED:
 
 ```c++
 if (clusterId == OnOff::Id && attributeId == OnOff::Attributes::OnOff::Id)


### PR DESCRIPTION
## Description
Rename ZclCallbacks.cpp to DataModelCallbacks.cpp

## Related Issue
<!-- If this pull request addresses an issue, link to it here. -->
Closes #<issue_number>

## Changes Made
Rename ZclCallbacks.cpp to DataModelCallbacks.cpp since the file was renamed in the Matter Extension.  

## Checklist
- [X] I have read the [Contributor License Agreement](https://github.com/SiliconLabsSoftware/agreements-and-guidelines/blob/main/contributor_license_agreement.md).
- [X] I have followed the repository's [coding guidelines](https://github.com/SiliconLabsSoftware/agreements-and-guidelines/blob/main/coding_standard.md) .
- [X] I have checked the action workflow results and they are all passed.

## Screenshots (if applicable)
<!-- Add screenshots to help explain the changes (if applicable). -->

## Additional Notes
<!-- Add any additional information or context. -->
