### PR TITLE
MATTER-6199: Updated Build Matter+AWS Docs

### DIFF
--- a/sld962-matter-aws-feature/build-matter-aws.md
+++ b/sld962-matter-aws-feature/build-matter-aws.md
@@ -1,6 +1,6 @@
 # Build Procedure For Matter + AWS
 
-The following steps are for adding the AWS configurations in the Matter SDK.
+Below steps are to be followed for setting the AWS configuration in the Matter SDK.
 
 ## Adding the AWS Server, Client ID and Cluster Details
 

--- a/sld962-matter-aws-feature/build-matter-aws.md
+++ b/sld962-matter-aws-feature/build-matter-aws.md
@@ -27,13 +27,9 @@ Below steps are to be followed for setting the AWS configuration in the Matter S
     ![MatterAwsConfig.h File](./images/matter-aws-config.png)
 
 4. After making the above changes, refresh the `matter-extension` in Simplicity Studio.
-
-5. In the **Home** tab, from the left panel, select **Settings**.
-
+   - In the **Home** tab, from the left panel, select **Settings**.
    ![Select Settings](images/aws-build-settings.jpg)
-
-6. Click on **SDKs**, ensure the correct version of the SDK is selected, and then click **Refresh** in the right side menu.
-
+   - Click on **SDKs**, ensure the correct version of the SDK is selected, and then click **Refresh** in the right side menu.
    ![Select Refresh](images/aws-build-sdk-refresh.jpg)
 
 The following steps are common for all apps and should be modified using the Studio Project Configurator tool.

--- a/sld962-matter-aws-feature/build-matter-aws.md
+++ b/sld962-matter-aws-feature/build-matter-aws.md
@@ -1,5 +1,41 @@
 # Build Procedure For Matter + AWS
 
+The following steps are for adding the AWS configurations in the Matter SDK.
+
+## Adding the AWS Server, Client ID and Cluster Details
+
+1. Open Simplicity Studio. Go to `Settings > SDKs`. Click **Browse to Location** option by right-clicking **Silicon Labs Matter**.
+   ![Matter Extension Browse to Location](images/aws-sdk-location.png)
+
+2. Go to the `third_party/matter_sdk/examples/platform/silabs/matter_aws/matter_aws_interface/include/`.   
+
+3. Update the definitions for the server ID, client ID and cluster in `MatterAwsConfig.h`:
+
+   - Update the AWS server name at `#define MATTER_AWS_SERVER_HOST ""`.
+   - Update the client ID at `#define MATTER_AWS_CLIENT_ID ""`.
+   - Update the cluster server information from the below table, based on your app:
+  
+   | Application Type | Cluster Definition |
+   |------------------|--------------------|
+   | Thermostat | `#define ZCL_USING_THERMOSTAT_CLUSTER_SERVER` |
+   | Lighting | `#define ZCL_USING_ON_OFF_CLUSTER_SERVER` |
+   | Lock | `#define ZCL_USING_DOOR_LOCK_CLUSTER_SERVER` |
+   | Window Covering | `#define ZCL_USING_WINDOW_COVERING_CLUSTER_SERVER` |
+
+    **MatterAwsConfig.h File:**
+
+    ![MatterAwsConfig.h File](./images/matter-aws-config.png)
+
+4. After making the above changes, refresh the `matter-extension` in Simplicity Studio.
+
+5. In the **Home** tab, from the left panel, select **Settings**.
+
+   ![Select Settings](images/aws-build-settings.jpg)
+
+6. Click on **SDKs**, ensure the correct version of the SDK is selected, and then click **Refresh** in the right side menu.
+
+   ![Select Refresh](images/aws-build-sdk-refresh.jpg)
+
 The following steps are common for all apps and should be modified using the Studio Project Configurator tool.
 
 ## Adding the Matter + AWS Component
@@ -30,44 +66,11 @@ To enable the component in Simplicity Studio, add the following components.
 
    ![TLS 1.2 PRF Component](images/tls-prf-component-install.png)
 
-## Adding the AWS Server, Client ID and Cluster Details
-
-1. Go to the `third_party/matter_sdk/examples/platform/silabs/matter_aws/matter_aws_interface/include/` folder from **Browse to Location** option by right-clicking **Silicon Labs Matter** in `Settings > SDKs`.
-
-   ![Matter Extension Browse to Location](images/aws-sdk-location.png)
-
-2. Update the definitions for the server ID, client ID and cluster in `MatterAwsConfig.h`:
-
-   - Update the AWS server name at `#define MATTER_AWS_SERVER_HOST ""`.
-   - Update the client ID at `#define MATTER_AWS_CLIENT_ID ""`.
-   - Update the cluster server information from the below table, based on your app:
-  
-   | Application Type | Cluster Definition |
-   |------------------|--------------------|
-   | Thermostat | `#define ZCL_USING_THERMOSTAT_CLUSTER_SERVER` |
-   | Lighting | `#define ZCL_USING_ON_OFF_CLUSTER_SERVER` |
-   | Lock | `#define ZCL_USING_DOOR_LOCK_CLUSTER_SERVER` |
-   | Window Covering | `#define ZCL_USING_WINDOW_COVERING_CLUSTER_SERVER` |
-
-    **MatterAwsConfig.h File:**
-
-    ![MatterAwsConfig.h File](./images/matter-aws-config.png)
-
 ## Building Matter + AWS Application
 
-1. After adding the Matter + AWS component as described above, refresh the `matter-extension` in Simplicity Studio.
+1. After adding the Matter + AWS component as described above, build the Matter + AWS application using Simplicity Studio as described in [Build SOC Application Using Studio](/matter/{build-docspace-version}/matter-wifi-run-demo/build-soc-application-using-studio).
 
-2. In the **Home** tab, from the left panel, select **Settings**.
-
-   ![Select Settings](images/aws-build-settings.jpg)
-
-3. Click on **SDKs**, ensure the correct version of the SDK is selected, and then click **Refresh** in the right side menu.
-
-   ![Select Refresh](images/aws-build-sdk-refresh.jpg)
-
-4. Build the Matter + AWS application using Simplicity Studio as described in [Build SOC Application Using Studio](/matter/{build-docspace-version}/matter-wifi-run-demo/build-soc-application-using-studio).
-
-5. After building and flashing the app, you can see [MATTER_AWS] logs after device bootup.
+2. After building and flashing the app, you can see [MATTER_AWS] logs after device bootup.
 
     ```console
     [00:00:23.400][info  ][SVR] [MATTER_AWS] connection callback started
@@ -75,11 +78,11 @@ To enable the component in Simplicity Studio, add the following components.
     [00:00:23.995][info  ][SVR] [MATTER_AWS] MQTT sub request callback: 0
     ```
 
-6. After subscribing to a topic in AWS IoT, you can see the publish logs.
+3. After subscribing to a topic in AWS IoT, you can see the publish logs.
 
    ![Device Logs AWS](./images/aws-device-logs-thermostat-app.png)
 
-7. You can see the same data in AWS IoT.
+4. You can see the same data in AWS IoT.
 
    ![AWS IoT App Data](./images/matter-aws-iot-app-data.png)
 

--- a/sld962-matter-aws-feature/build-matter-aws.md
+++ b/sld962-matter-aws-feature/build-matter-aws.md
@@ -1,19 +1,19 @@
 # Build Procedure For Matter + AWS
 
-Below steps are to be followed for setting the AWS configuration in the Matter SDK.
+Follow the steps below to set the AWS configuration in the Matter SDK.
 
-## Adding the AWS Server, Client ID and Cluster Details
+## Adding the AWS Server, Client ID, and Cluster Details
 
 1. Open Simplicity Studio. Go to `Settings > SDKs`. Click **Browse to Location** option by right-clicking **Silicon Labs Matter**.
    ![Matter Extension Browse to Location](images/aws-sdk-location.png)
 
 2. Go to the `third_party/matter_sdk/examples/platform/silabs/matter_aws/matter_aws_interface/include/`.   
 
-3. Update the definitions for the server ID, client ID and cluster in `MatterAwsConfig.h`:
+3. Update the definitions for the server ID, client ID, and cluster in `MatterAwsConfig.h`:
 
    - Update the AWS server name at `#define MATTER_AWS_SERVER_HOST ""`.
    - Update the client ID at `#define MATTER_AWS_CLIENT_ID ""`.
-   - Update the cluster server information from the below table, based on your app:
+   - Update the cluster server information as shown in the table below, based on your app:
   
    | Application Type | Cluster Definition |
    |------------------|--------------------|
@@ -29,7 +29,7 @@ Below steps are to be followed for setting the AWS configuration in the Matter S
 4. After making the above changes, refresh the `matter-extension` in Simplicity Studio.
    - In the **Home** tab, from the left panel, select **Settings**.
    ![Select Settings](images/aws-build-settings.jpg)
-   - Click on **SDKs**, ensure the correct version of the SDK is selected, and then click **Refresh** in the right side menu.
+   - Click **SDKs**, ensure the correct version of the SDK is selected, and then click **Refresh** in the right side menu.
    ![Select Refresh](images/aws-build-sdk-refresh.jpg)
 
 The following steps are common for all apps and should be modified using the Studio Project Configurator tool.


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this pull request. -->
<!-- Note that the pull requests must be merged into the doccurator branches corresponding to the Matter release the change applies to, for example doccurator/2.6.2 . -->
The “Build Procedure For Matter + AWS” docs can be read as: compile/flash the app first, then change the SDK / matter-extension repo. The correct workflow for real use is: update the Matter SDK sources (AWS host, client ID, cluster defines, and device certs when not using PoC defaults) in the repo first, then refresh sdk, then create > build and flash.

## Related Issue
<!-- If this pull request addresses an issue, link to it here. -->
MATTER-6199

## Changes Made
<!-- List the changes made in this pull request. -->
Updated the flow: 
 - update the Matter SDK sources (AWS host, client ID, cluster defines, and device certs when not using PoC defaults) in the repo first, 
 - refresh sdk, then create > build and flash.

## Checklist
- [x] I have read the [Contributor License Agreement](https://github.com/SiliconLabsSoftware/agreements-and-guidelines/blob/main/contributor_license_agreement.md).
- [x] I have followed the repository's [coding guidelines](https://github.com/SiliconLabsSoftware/agreements-and-guidelines/blob/main/coding_standard.md) .
- [x] I have checked the action workflow results and they are all passed.

## Screenshots (if applicable)
<!-- Add screenshots to help explain the changes (if applicable). -->

## Additional Notes
<!-- Add any additional information or context. -->
